### PR TITLE
seatbelt: generate unique secret signing key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .DS_Store
 
+master.key

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gorilla/csrf v1.7.1
 	github.com/gorilla/securecookie v1.1.1
 	github.com/mitchellh/mapstructure v1.4.3
-	golang.org/x/text v0.3.7
 )
 
 require github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,3 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/gorilla/csrf"
-	_ "golang.org/x/text/message" // Required for commands to work.
 )
 
 // ChiPathParamFunc extracts path parameters from the given HTTP request using

--- a/seatbelt_test.go
+++ b/seatbelt_test.go
@@ -1,0 +1,22 @@
+package seatbelt
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOptions(t *testing.T) {
+	o := &Option{}
+
+	t.Run("a master.key file should be present after calling setDefaults", func(t *testing.T) {
+		o.setDefaults()
+
+		data, err := os.ReadFile("master.key")
+		if err != nil {
+			t.Fatalf("failed to read master.key file: %v", err)
+		}
+		if data == nil {
+			t.Fatal("file is empty")
+		}
+	})
+}


### PR DESCRIPTION
Removes the hardcoded hex string that was previously used as the default secret in favour of a randomly generated secret that is written to the file `master.key`.

Also removes the last unused dependency.