### PR TITLE
all: version public assets, improve sessions

### DIFF
--- a/example/public/css/style.css
+++ b/example/public/css/style.css
@@ -3,3 +3,7 @@ html, body {
   font-size: 16px;
   margin: 0;
 }
+
+.title {
+  font-size: 30px;
+}

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -1,7 +1,7 @@
 {{ define "title" }}Home{{ end }}
 
 {{ define "content" }}
-  <h1>Hello!</h1>
+  <h1 class="title">Hello!</h1>
   <p>Welcome to Seatbelt. This is a sample application that shows off all the framework can do.</p>
   <a href="/session">Set and view session data</a>
 {{ end }}

--- a/example/templates/layout.html
+++ b/example/templates/layout.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" type="text/css" href='{{ versionpath "/public/css/style.css" }}'/>
+  {{ csrfMetaTags }}
   <title>{{ block "title" . }}test{{ end }}</title>
-  <link rel="stylesheet" href="/public/css/style.css"/>
 </head>
 <body>
   {{ block "content" . }}<p>Hello</p>{{ end }}
-  <script src="/public/js/main.js"></script>
+  <script src='{{ versionpath "/public/js/main.js" }}'></script>
 </body>
 </html>

--- a/render/render.go
+++ b/render/render.go
@@ -67,11 +67,9 @@ func (r *Render) parseTemplates() error {
 	dirfs := os.DirFS(r.dir)
 
 	// Parse the layout template in order to clone it for each template later.
-	ltpl, err := template.New("layout").ParseFS(dirfs, "layout.html")
-	if err != nil {
-		log.Fatalln("[error] parsing layout template", err)
-		return err
-	}
+	// Because template functions may be defined in the layout, we also need
+	// to add them prior to actually doing any parsing.
+	basetpl := template.New("layout")
 
 	// Define an initial map of template funcs as no-ops. This will be passed
 	// to templates **before** parsing in order to prevent a "function not
@@ -86,7 +84,13 @@ func (r *Render) parseTemplates() error {
 				}
 			}
 		}
-		ltpl.Funcs(noopFuncMap)
+		basetpl.Funcs(noopFuncMap)
+	}
+
+	ltpl, err := basetpl.ParseFS(dirfs, "layout.html")
+	if err != nil {
+		log.Fatalln("[error] parsing layout template", err)
+		return err
 	}
 
 	rootDir := "."

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -264,7 +264,7 @@ func defaultTemplateFuncs(session *session.Session) func(w http.ResponseWriter, 
 				if err == nil {
 					path = path + "?" + strconv.Itoa(int(fi.ModTime().Unix()))
 				} else {
-					fmt.Printf("seatbelt: error getting css file info at path %s: %v\n", path, err)
+					fmt.Printf("seatbelt: error getting file info at path %s: %v\n", path, err)
 				}
 
 				return path

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/go-seatbelt/seatbelt/handler"
@@ -174,8 +176,15 @@ type Option struct {
 	// The directory containing your HTML templates.
 	TemplateDir string
 
-	// The signing key for the cookie session store.
+	// The signing key for the session cookie store.
 	SigningKey string
+
+	// The session name for the session cookie. Default is "_session".
+	SessionName string
+
+	// The MaxAge for the session cookie. Default is 365 days. Pass -1 for no
+	// max age.
+	SessionMaxAge int
 
 	// Request-contextual HTML functions.
 	Funcs func(w http.ResponseWriter, r *http.Request) template.FuncMap
@@ -241,6 +250,28 @@ func defaultTemplateFuncs(session *session.Session) func(w http.ResponseWriter, 
 			"flashes": func() map[string]interface{} {
 				return session.Flashes(w, r)
 			},
+			// versionpath takes a filepath and returns the same filepath with
+			// a query parameter appended that contains the unix timestamp of
+			// that file's last modified time. This should be used for files
+			// that might change between page loads (JavaScript and CSS files,
+			// images, etc).
+			"versionpath": func(path string) string {
+				path = filepath.Clean(path)
+
+				// Leading `/` characters will just break local filepath
+				// resolution, so we remove it if it exists.
+				fi, err := os.Stat(strings.TrimPrefix(path, "/"))
+				if err == nil {
+					path = path + "?" + strconv.Itoa(int(fi.ModTime().Unix()))
+				} else {
+					fmt.Printf("seatbelt: error getting css file info at path %s: %v\n", path, err)
+				}
+
+				return path
+			},
+			"csrfMetaTags": func() template.HTML {
+				return template.HTML(`<meta name="csrf-token" content="` + csrf.Token(r) + `">`)
+			},
 		}
 	}
 }
@@ -263,7 +294,10 @@ func New(opts ...Option) *App {
 	mux := chi.NewRouter()
 	mux.Use(csrf.Protect(signingKey))
 
-	sess := session.New(signingKey)
+	sess := session.New(signingKey, session.Options{
+		Name:   opt.SessionName,
+		MaxAge: opt.SessionMaxAge,
+	})
 
 	app := &App{
 		mux:        mux,


### PR DESCRIPTION
Adds the ability to version public assets (JS, CSS, images, etc) in templates by using the new `versionpath` helper. This appends a query parameter containing the last modified time, in order to purge the browser cache when assets are updated. This also required a change to the way helper funcs are loaded, as there was previously a bug that prevented user-defined template funcs from being used in layout files.

This also adds some configuration options to the session cookie. The name and max age of the session cookie can now be customized.

This also adds the `csrfMetaTags` template function that adds the CSRF meta tag.