### PR TITLE
ci: run against 1.18 and 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.17.x, 1.18.x ]
+        go-version: [ 1.18.x, 1.19.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -61,15 +61,17 @@ func JSON(w http.ResponseWriter, code int, v interface{}) error {
 // For example, if you're using the Chi router to parse the path parameters,
 // this method will look like:
 //
-// 	if rctx := chi.RouteContext(r.Context()); rctx != nil {
-// 		for i, key := range rctx.URLParams.Keys {
-// 			values[key] = rctx.URLParams.Values[i]
-// 		}
-// 	}
+//	if rctx := chi.RouteContext(r.Context()); rctx != nil {
+//		for i, key := range rctx.URLParams.Keys {
+//			values[key] = rctx.URLParams.Values[i]
+//		}
+//	}
 //
 // The top-level "seatbelt" package contains some PathParamFunc's for
 // different routers, i.e., users of github.com/go-chi/chi can use
+//
 //	seatbelt.ChiPathParamFunc
+//
 // as an argument in the Params function.
 type PathParamFunc func(r *http.Request, v map[string]interface{})
 


### PR DESCRIPTION
Upgrades GitHub Actions to run against Go 1.18 and Go 1.19, dropping support for 1.17.