### PR TITLE
render: rewrite to use unrolled/render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Seatbelt
 
-An MVC web framework for Go that balances upfront productivity with long term maintability.
-
-Inspired by Ruby on Rails.
+A web framework for Go that balances upfront productivity with long term maintability.
 
 ### Usage
 
@@ -11,4 +9,3 @@ Don't use this yet. It's too early.
 ### Notes
 
 1. Static assets are always served from `public`.
-2. HTML templates go in `views`. If a `layout.html` is present, that is used as a layout file.

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -1,7 +1,4 @@
-{{ define "title" }}Home{{ end }}
-
-{{ define "content" }}
-  <h1 class="title">Hello!</h1>
-  <p>Welcome to Seatbelt. This is a sample application that shows off all the framework can do.</p>
-  <a href="/session">Set and view session data</a>
-{{ end }}
+{{ define "title-index" }}Home{{ end }}
+<h1 class="title">Hello!</h1>
+<p>Welcome to Seatbelt. This is a sample application that shows off all the framework can do.</p>
+<a href="/session">Set and view session data</a>

--- a/example/templates/layout.html
+++ b/example/templates/layout.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href='{{ versionpath "/public/css/style.css" }}'/>
   {{ csrfMetaTags }}
-  <title>{{ block "title" . }}test{{ end }}</title>
+  <title>{{ $title := partial "title" }}{{ with $title }}{{ . }}{{ else }}test{{ end }}</title>
 </head>
 <body>
-  {{ block "content" . }}<p>Hello</p>{{ end }}
+  {{ yield }}
   <script src='{{ versionpath "/public/js/main.js" }}'></script>
 </body>
 </html>

--- a/example/templates/session.html
+++ b/example/templates/session.html
@@ -1,36 +1,32 @@
-{{ define "title" }}Session{{ end }}
+{{ define "title-session" }}Session{{ end }}
+<a href="/">Back to home</a>
+<h1>Session</h1>
 
-{{ define "content" }}
-  <a href="/">Back to home</a>
-  <h1>Session</h1>
+{{ range $key, $val := flashes }}
+  <p>{{ $key }}: {{ $val }}</p>
+{{ end }}
 
-  {{ range $key, $val := flashes }}
-    <p>{{ $key }}: {{ $val }}</p>
-  {{ end }}
+<form action="/session" method="POST">
+  {{ csrf }}
+  <div>
+    <label for="session">Session</label>
+    <input type="text" id="session" name="session" placeholder="Enter a session message here">
+  </div>
 
-  <form action="/session" method="POST">
-    {{ csrf }}
-    <div>
-      <label for="session">Session</label>
-      <input type="text" id="session" name="session" placeholder="Enter a session message here">
-    </div>
+  <div>
+    <label for="flash">Flash</label>
+    <input type="text" id="flash" name="flash" placeholder="Enter a flash message here">
+  </div>
 
-    <div>
-      <label for="flash">Flash</label>
-      <input type="text" id="flash" name="flash" placeholder="Enter a flash message here">
-    </div>
+  <div>
+    <label for="error">Error (use this to force the handler to return an error)</label>
+    <input type="text" id="error" name="error" placeholder="Enter an error here">
+  </div>
 
-    <div>
-      <label for="error">Error (use this to force the handler to return an error)</label>
-      <input type="text" id="error" name="error" placeholder="Enter an error here">
-    </div>
+  <input type="submit" value="Submit"/>
+  <input type="submit" formaction="/session/reset" value="Clear all session data"/>
+</form>
 
-    <input type="submit" value="Submit"/>
-    <input type="submit" formaction="/session/reset" value="Clear all session data"/>
-  </form>
-
-  {{ with .Session }}
-    <p>{{ . }}</p>
-  {{ end }}
-
+{{ with .Session }}
+  <p>{{ . }}</p>
 {{ end }}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,11 @@ require (
 	github.com/gorilla/csrf v1.7.1
 	github.com/gorilla/securecookie v1.1.1
 	github.com/mitchellh/mapstructure v1.4.3
+	github.com/unrolled/render v1.5.0
 )
 
-require github.com/pkg/errors v0.9.1 // indirect
+require (
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/sys v0.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
 github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
 github.com/gorilla/csrf v1.7.1 h1:Ir3o2c1/Uzj6FBxMlAUB6SivgVMy1ONXwYgXn+/aHPE=
@@ -8,3 +10,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/unrolled/render v1.5.0 h1:uNTHMvVoI9pyyXfgoDHHycIqFONNY2p4eQR9ty+NsxM=
+github.com/unrolled/render v1.5.0/go.mod h1:eLTosBkQqEPEk7pRfkCRApXd++lm++nCsVlFOHpeedw=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/render/render.go
+++ b/render/render.go
@@ -3,18 +3,14 @@
 package render
 
 import (
-	"bytes"
 	"fmt"
 	"html/template"
 	"io"
-	"io/fs"
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
-	"sync"
+
+	"github.com/unrolled/render"
 )
 
 // A ContextualFuncMap is a function that returns an HTML template.FuncMap.
@@ -24,125 +20,74 @@ import (
 type ContextualFuncMap func(w http.ResponseWriter, r *http.Request) template.FuncMap
 
 type Render struct {
-	dir    string
-	mu     sync.Mutex
-	pool   sync.Pool
-	tpls   map[string]*template.Template
-	funcs  []ContextualFuncMap
-	reload bool
+	re    *render.Render
+	funcs []ContextualFuncMap
 }
 
 type Options struct {
-	Dir    string
-	Funcs  []ContextualFuncMap
+	// The directory to serve templates from. Default is "templates".
+	Dir string
+
+	// The template to use as a layout. Layouts can call {{ yield }}. Defaults
+	// to an empty string (meaning a layout is not used).
+	Layout string
+
+	// Request-scoped template funcs. Default is nil.
+	Funcs []ContextualFuncMap
+
+	// Whether or not to recompile templates. Default is false. Do not
+	// recompile templates in production, as this adds a significant
+	// performance penalty.
 	Reload bool
 }
 
-func New(o Options) *Render {
-	r := &Render{
-		dir: o.Dir,
-		pool: sync.Pool{
-			New: func() interface{} {
-				return &bytes.Buffer{}
-			},
-		},
-		funcs:  o.Funcs,
-		reload: o.Reload,
+func New(o *Options) *Render {
+	if o == nil {
+		o = &Options{}
 	}
 
-	r.mu.Lock()
-	if err := r.parseTemplates(); err != nil {
-		log.Fatalln("[fatal] failed to parse templates:", err)
-	}
-	r.mu.Unlock()
+	// TODO Consider adding a preprocessing step to:
+	//
+	// 	* Automatically add the required templates suffixes within the
+	//	  `define` blocks.
+	//	* Allow for a default value for the `{{ partial }}` helper func,
+	//	  potentially something that expands
+	//		{{ partial "title" "fallback "}}
+	//	  to
+	//		{{ $title := partial "title" }}
+	//		{{ with $title }}{{ . }}{{ else }}fallback{{ end }}
+	//	  which is painfully verbose.
 
-	return r
-}
-
-func (r *Render) parseTemplates() error {
-	if r.tpls == nil {
-		r.tpls = make(map[string]*template.Template)
-	}
-
-	dirfs := os.DirFS(r.dir)
-
-	// Parse the layout template in order to clone it for each template later.
-	// Because template functions may be defined in the layout, we also need
-	// to add them prior to actually doing any parsing.
-	basetpl := template.New("layout")
-
-	// Define an initial map of template funcs as no-ops. This will be passed
-	// to templates **before** parsing in order to prevent a "function not
-	// defined" error. This func map is redefined when templates are rendered,
-	// and is provided with request-specific information.
-	if r.funcs != nil {
-		noopFuncMap := make(map[string]interface{})
-		for _, fn := range r.funcs {
-			if fn != nil {
-				for name := range fn(nil, nil) {
-					noopFuncMap[name] = func() struct{} { return struct{}{} }
-				}
+	// Mock the template funcs by passing in the user-defined template funcs
+	// as no-ops in order for the templates to compile successfully. The real
+	// implementations are injected at render time.
+	mocks := make(map[string]interface{})
+	if o.Funcs != nil {
+		for _, fn := range o.Funcs {
+			for k := range fn(nil, nil) {
+				mocks[k] = func() template.HTML { return "" }
 			}
 		}
-		basetpl.Funcs(noopFuncMap)
 	}
 
-	ltpl, err := basetpl.ParseFS(dirfs, "layout.html")
-	if err != nil {
-		log.Fatalln("[error] parsing layout template", err)
-		return err
-	}
-
-	rootDir := "."
-	return fs.WalkDir(dirfs, rootDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d == nil || d.IsDir() {
-			return nil
-		}
-
-		rel, err := filepath.Rel(rootDir, path)
-		if err != nil {
-			return err
-		}
-
-		ext := ""
-		if strings.Contains(rel, ".") {
-			ext = filepath.Ext(rel)
-		}
-		if ext != ".html" {
-			log.Fatalf("[error] template %s must end in .html, got %s\n", path, ext)
-			return fmt.Errorf("template %s must end in .html, got %s", path, ext)
-		}
-
-		name := rel[0 : len(rel)-len(ext)]
-
-		// On Windows, replace the OS-specific path separator "\" with the
-		// conventional Linux/Mac one.
-		name = strings.Replace(name, `\`, "/", -1)
-
-		clone, err := ltpl.Clone()
-		if err != nil {
-			log.Println("[info] failed to clone layout tempalate", err)
-			return err
-		}
-
-		_, err = clone.ParseFS(dirfs, path)
-		if err != nil {
-			log.Fatalf("[error] failed to parse template %s at path %s: %#v", name, path, err)
-			return fmt.Errorf("failed to parse template %s at path %s: %w", name, path, err)
-		}
-
-		r.tpls[name] = clone
-
-		return nil
+	re := render.New(render.Options{
+		Directory:     o.Dir,
+		Layout:        o.Layout,
+		Extensions:    []string{".html"},
+		IsDevelopment: o.Reload,
+		Funcs:         []template.FuncMap{mocks},
 	})
+
+	return &Render{
+		re:    re,
+		funcs: o.Funcs,
+	}
 }
 
 type RenderOptions struct {
+	Layout     string
 	StatusCode int
+	Headers    map[string]string
 }
 
 func (r *RenderOptions) setDefaults() {
@@ -162,17 +107,6 @@ func (r *Render) TextError(w io.Writer, error string, code int) {
 	w.Write([]byte(error))
 }
 
-// DefinedTemplates returns a comma-separated string containing the names of
-// all defined templates. Used to generate an error message, but can also be
-// used for debugging.
-func (r *Render) DefinedTemplates() string {
-	names := make([]string, 0, len(r.tpls))
-	for name := range r.tpls {
-		names = append(names, name)
-	}
-	return strings.Join(names, ",")
-}
-
 // HTML renders the HTML template with the given name. The HTTP request is
 // optional, and can be set to nil. It is only used to add request-specific
 // context to HTML template functions.
@@ -183,35 +117,16 @@ func (r *Render) HTML(w io.Writer, req *http.Request, name string, data map[stri
 	}
 	o.setDefaults()
 
-	b := r.pool.Get().(*bytes.Buffer)
-	b.Reset()
-	defer r.pool.Put(b)
-
-	if r.reload {
-		r.mu.Lock()
-		r.parseTemplates()
-		r.mu.Unlock()
-	}
-
-	if r.reload {
-		r.mu.Lock()
-	}
-	tpl, ok := r.tpls[name]
-	if r.reload {
-		r.mu.Unlock()
-	}
-
-	if !ok {
-		msg := fmt.Sprintf(`no template named "%s", defined templates are %s`,
-			name, r.DefinedTemplates())
-		r.TextError(w, msg, http.StatusInternalServerError)
-		return
-	}
-
 	// Prevent read from nil errors by ensuring the map is always initialized.
+	//
+	// TODO In Seatbelt, this should come from the newly propsed `Values`
+	// feature.
 	if data == nil {
 		data = make(map[string]interface{})
 	}
+
+	// Prepare the render options.
+	htmlOpts := render.HTMLOptions{Layout: o.Layout}
 
 	// Add the template funcs, providing the context of the current request,
 	// if one is provided.
@@ -219,26 +134,39 @@ func (r *Render) HTML(w io.Writer, req *http.Request, name string, data map[stri
 	if ok {
 		if req != nil {
 			if r.funcs != nil {
+				mergedFuncMap := make(map[string]interface{})
+
 				for _, fn := range r.funcs {
-					if fn != nil {
-						tpl.Funcs(fn(rw, req))
+					m := fn(rw, req)
+					for k, v := range m {
+						if _, ok := mergedFuncMap[k]; ok {
+							fmt.Printf("[warning] seatbelt/render.HTML: func %s overrides existing func\n", k)
+						} else {
+							mergedFuncMap[k] = v
+						}
 					}
 				}
+
+				htmlOpts.Funcs = mergedFuncMap
 			}
 		}
 	}
-
-	if err := tpl.ExecuteTemplate(b, "layout.html", data); err != nil {
-		log.Printf("[error] failed to execute template %s: %v", name, err)
-		r.TextError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	if ok {
-		rw.Header().Set("Content-Type", "text/html")
+		for k, v := range o.Headers {
+			rw.Header().Set(k, v)
+		}
 		rw.WriteHeader(o.StatusCode)
 	}
-	if _, err := b.WriteTo(w); err != nil {
-		log.Println("[error] failed to write response:", err)
+
+	// Even if the template isn't found, the given status code is respected.
+	// This is somewhat confusing, but works better in a
+	// Turbo (https://turbo.hotwired.dev/) context because it causes the error
+	// page rendered by unrolled/render to actually show  up instead of being
+	// silently dropped due to the >=400 level status code.
+	//
+	// If an error occurs, the reponse has already been written meaning that
+	// it's too late to intervene, so the best we can do is log it.
+	if err := r.re.HTML(w, o.StatusCode, name, data, htmlOpts); err != nil {
+		log.Printf("seatbelt/render: failed to render template: %v", err)
 	}
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -61,7 +61,7 @@ func TestRender(t *testing.T) {
 		}
 	})
 
-	t.Run("render a non-existent template should 200 with an error message", func(t *testing.T) {
+	t.Run("render a non-existent template should 500 with an error message", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		tr := httptest.NewRequest(http.MethodGet, "/", nil)
 
@@ -72,7 +72,7 @@ func TestRender(t *testing.T) {
 		h(rr, tr)
 
 		code := rr.Result().StatusCode
-		expected := 200
+		expected := 500
 		if code != expected {
 			t.Errorf("expected status code %d but got %d", expected, code)
 		}

--- a/render/testdata/templates/home.html
+++ b/render/testdata/templates/home.html
@@ -1,0 +1,2 @@
+{{ define "title-home" }}home{{ end }}
+<h1>{{ path }}</h1>

--- a/render/testdata/templates/index.html
+++ b/render/testdata/templates/index.html
@@ -1,5 +1,2 @@
-{{ define "title" }}test2{{ end }}
-
-{{ define "content" }}
-  <h1>test2</h1>
-{{ end }}
+{{ define "title-index" }}index{{ end }}
+<h1>test index</h1>

--- a/render/testdata/templates/layout.html
+++ b/render/testdata/templates/layout.html
@@ -3,9 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ block "title" . }}test{{ end }}</title>
+  <title>{{ $title := partial "title" }}{{ with $title }}{{ . }}{{ else }}layout{{ end }}</title>
 </head>
 <body>
-  {{ block "content" . }}<p>Hello</p>{{ end }}
+  {{ yield }}
 </body>
 </html>
+{{ define "title "}}test{{ end }}

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -276,19 +276,6 @@ func defaultTemplateFuncs(session *session.Session) func(w http.ResponseWriter, 
 	}
 }
 
-// mergeFuncMaps merges the two given maps. If a collision occurs between the
-// two maps, m1 "wins", but will log a warning to say that the collision
-// occured.
-func mergeFuncMaps(m1, m2 map[string]interface{}) {
-	for k, v := range m2 {
-		if _, ok := m1[k]; ok {
-
-		} else {
-			m1[k] = v
-		}
-	}
-}
-
 // New returns a new instance of a Seatbelt application.
 func New(opts ...Option) *App {
 	var opt Option

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -276,6 +276,19 @@ func defaultTemplateFuncs(session *session.Session) func(w http.ResponseWriter, 
 	}
 }
 
+// mergeFuncMaps merges the two given maps. If a collision occurs between the
+// two maps, m1 "wins", but will log a warning to say that the collision
+// occured.
+func mergeFuncMaps(m1, m2 map[string]interface{}) {
+	for k, v := range m2 {
+		if _, ok := m1[k]; ok {
+
+		} else {
+			m1[k] = v
+		}
+	}
+}
+
 // New returns a new instance of a Seatbelt application.
 func New(opts ...Option) *App {
 	var opt Option
@@ -303,8 +316,9 @@ func New(opts ...Option) *App {
 		mux:        mux,
 		signingKey: signingKey,
 		session:    sess,
-		renderer: render.New(render.Options{
+		renderer: render.New(&render.Options{
 			Dir:    opt.TemplateDir,
+			Layout: "layout",
 			Reload: opt.Reload,
 			Funcs: []render.ContextualFuncMap{
 				defaultTemplateFuncs(sess),

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -299,6 +299,11 @@ func New(opts ...Option) *App {
 		MaxAge: opt.SessionMaxAge,
 	})
 
+	funcMaps := []render.ContextualFuncMap{defaultTemplateFuncs(sess)}
+	if opt.Funcs != nil {
+		funcMaps = append(funcMaps, opt.Funcs)
+	}
+
 	app := &App{
 		mux:        mux,
 		signingKey: signingKey,
@@ -307,10 +312,7 @@ func New(opts ...Option) *App {
 			Dir:    opt.TemplateDir,
 			Layout: "layout",
 			Reload: opt.Reload,
-			Funcs: []render.ContextualFuncMap{
-				defaultTemplateFuncs(sess),
-				opt.Funcs,
-			},
+			Funcs:  funcMaps,
 		}),
 	}
 


### PR DESCRIPTION
Updates the rendering package to use the popular and battle-tested `github.com/unrolled/render`. I was initially going to use it, but didn't like their approach to rendering "partials" (or "blocks"), and their wasn't an API exposed to easily inject context-specific template functions.

I changed my mind about the partial stuff after getting frustrated with this library's current approach of duplicating the template tree for every single template, and `render` added a way to pass template funcs at render time, so I'm switching over.

This is a significant breaking change, as it changes the way HTML templates should be created. I'll cut a new minor release (instead of a patch).