### PR TITLE
seatbelt: add 'values' api

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -13,6 +13,15 @@ func main() {
 		Reload:      true,
 	})
 
+	app.Use(func(fn func(ctx *seatbelt.Context) error) func(*seatbelt.Context) error {
+		const name = "me"
+
+		return func(ctx *seatbelt.Context) error {
+			ctx.SetValue("Name", name)
+			return fn(ctx)
+		}
+	})
+
 	app.Get("/", func(c *seatbelt.Context) error {
 		return c.Render("index", nil)
 	})

--- a/example/templates/layout.html
+++ b/example/templates/layout.html
@@ -8,6 +8,7 @@
   <title>{{ $title := partial "title" }}{{ with $title }}{{ . }}{{ else }}test{{ end }}</title>
 </head>
 <body>
+  <div>{{ .Name }}</div>
   {{ yield }}
   <script src='{{ versionpath "/public/js/main.js" }}'></script>
 </body>


### PR DESCRIPTION
Adds a new "values" API to allow the setting of request-scoped value. This is useful in middleware, i.e., to set the current user on every request, rather than having to call that function in each handler.

I'm not crazy about the naming of the methods on a `*Context` now (`Set` vs. `SetValue` is confusing), so I'll probably end up changing it before any major release.