### PR TITLE
seatbelt: namespace methods, add values pkg, reload i18n

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -17,9 +17,9 @@ func main() {
 	app.Use(func(fn func(ctx *seatbelt.Context) error) func(*seatbelt.Context) error {
 		const name = "me"
 
-		return func(ctx *seatbelt.Context) error {
-			ctx.SetValue("Name", name)
-			return fn(ctx)
+		return func(c *seatbelt.Context) error {
+			c.Values.Set("Name", name)
+			return fn(c)
 		}
 	})
 
@@ -28,7 +28,7 @@ func main() {
 	})
 	app.Get("/session", func(c *seatbelt.Context) error {
 		return c.Render("session", map[string]interface{}{
-			"Session": c.Get("session"),
+			"Session": c.Session.Get("session"),
 		})
 	})
 	app.Post("/session", func(c *seatbelt.Context) error {
@@ -46,17 +46,17 @@ func main() {
 		}
 
 		if v.Session != "" {
-			c.Set("session", v.Session)
+			c.Session.Set("session", v.Session)
 		}
 		if v.Flash != "" {
-			c.Flash("notice", v.Flash)
+			c.Flash.Add("notice", v.Flash)
 		}
 
 		return c.Redirect("/session")
 	})
 
 	app.Post("/session/reset", func(c *seatbelt.Context) error {
-		c.Reset()
+		c.Session.Reset()
 		return c.Redirect("/session")
 	})
 

--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -61,7 +61,7 @@ func main() {
 	})
 
 	app.Get("/txt", func(c *seatbelt.Context) error {
-		return c.String(200, c.I18N.T("Hello", nil))
+		return c.String(200, c.I18N.T("Greet", nil))
 	})
 
 	log.Fatalln(app.Start(":3000"))

--- a/example/locales/active.en.json
+++ b/example/locales/active.en.json
@@ -5,6 +5,9 @@
   "Hello": {
     "other": "Hello"
   },
+  "Greet": {
+    "other": "Hello, {{ .Name }}"
+  },
   "WelcomeMessage": {
     "other": "Welcome to Seatbelt. This is a sample application that shows off all the framework can do."
   },

--- a/example/locales/active.fr.json
+++ b/example/locales/active.fr.json
@@ -5,6 +5,9 @@
   "Hello": {
     "other": "Salut"
   },
+  "Greet": {
+    "other": "Salut, {{ .Name }}"
+  },
   "WelcomeMessage": {
     "other": "Bienvenue à Seatbelt. Voici un application qui démontre tout que le framework peut faire."
   },

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -1,5 +1,6 @@
 {{ define "title-index" }}{{ t "Home" . }}{{ end }}
 <h1 class="title">{{ t "Hello" . }}</h1>
+<p>{{ t "Greet" . }}</p>
 <p>{{ t "WelcomeMessage" . }}</p>
 <a href="/session">{{ t "SessionData" . }}</a>
 <a href="/txt">Plaintext link</a>

--- a/example/templates/layout.html
+++ b/example/templates/layout.html
@@ -8,7 +8,6 @@
   <title>{{ $title := partial "title" }}{{ with $title }}{{ . }}{{ else }}test{{ end }}</title>
 </head>
 <body>
-  <div>{{ .Name }}</div>
   {{ yield }}
   <script src='{{ versionpath "/public/js/main.js" }}'></script>
 </body>

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTranslator(t *testing.T) {
-	translator := New("testdata")
+	translator := New("testdata", false)
 
 	req := httptest.NewRequest(http.MethodGet, "/?locale=fr", nil)
 

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -381,7 +381,7 @@ func New(opts ...Option) *App {
 		log.Fatalf("seatbelt: signing key is not a valid hexadecimal string: %+v", err)
 	}
 
-	translator := i18n.New(opt.LocaleDir)
+	translator := i18n.New(opt.LocaleDir, opt.Reload)
 
 	// Initialize the underlying chi mux so that we can setup our default
 	// middleware stack.

--- a/values/values.go
+++ b/values/values.go
@@ -1,0 +1,72 @@
+package values
+
+import (
+	"context"
+	"net/http"
+)
+
+var valueskey = struct{}{}
+
+type Values struct {
+	r   *http.Request
+	key interface{}
+}
+
+func New(r *http.Request) *Values {
+	return &Values{
+		r:   r,
+		key: valueskey,
+	}
+}
+
+// values returns the map saved on the current request's context, or creates
+// it if it's not present.
+func (v *Values) values() map[string]interface{} {
+	m := v.r.Context().Value(v.key)
+	if m == nil {
+		// If m is nil, create the map, save it on the context, and return it.
+		data := make(map[string]interface{})
+		v.save(data)
+		return data
+	}
+
+	data, ok := m.(map[string]interface{})
+	if !ok {
+		// TODO Log warning message, even though this code path shouldn't be
+		// reachable.
+		return map[string]interface{}{}
+	}
+
+	return data
+}
+
+// save saves the map on the current request context.
+func (v *Values) save(m map[string]interface{}) {
+	v.r = v.r.WithContext(context.WithValue(v.r.Context(), v.key, m))
+}
+
+// Set sets the given key value pair on the request. These values are
+// passed to every HTML template by merging them with the given `data`.
+func (v *Values) Set(key string, value any) {
+	data := v.values()
+	data[key] = value
+	v.save(data)
+}
+
+// Get returns the request-scoped value with the given key.
+func (v *Values) Get(key string) any {
+	data := v.values()
+	return data[key]
+}
+
+// List returns all request-scoped values.
+func (v *Values) List() map[string]any {
+	return v.values()
+}
+
+// Delete deletes the given request-scoped value.
+func (v *Values) Delete(key string) {
+	data := v.values()
+	delete(data, key)
+	v.save(data)
+}

--- a/values/values_test.go
+++ b/values/values_test.go
@@ -1,0 +1,46 @@
+package values
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValues(t *testing.T) {
+	v := New(httptest.NewRequest(http.MethodGet, "/", nil))
+	expected := "value"
+
+	t.Run("set and get", func(t *testing.T) {
+		v.Set("key", expected)
+
+		actual := v.Get("key").(string)
+
+		if expected != actual {
+			t.Fatalf("expected %s but got %s", expected, actual)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		vs := v.List()
+
+		if n := len(vs); n != 1 {
+			t.Fatalf("expected length 1 but got %d", n)
+		}
+
+		actual := vs["key"].(string)
+
+		if expected != actual {
+			t.Fatalf("expected %s but got %s", expected, actual)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		v.Delete("key")
+
+		data := v.List()
+
+		if n := len(data); n != 0 {
+			t.Fatalf("expected length to be zero but got %d", n)
+		}
+	})
+}


### PR DESCRIPTION
Adds namespaces to the context methods to more clearly group them by functionality, i.e., methods affecting the session are now accessed via,

```go
func Handle(c *seatbelt.Context) error {
    c.Session.Set("key", "value")
    return nil
}
```

This also adds a helper to approximate the IP address of a request.

Updates the "values" API so that it used the request context for storage, rather than relying on a per-request map stored in the context instance.

This allows us to create arbitrary "values" instances from requests, which makes it possible to interact with this API anytime we have an HTTP request. This was required to merge the request-scoped "values" in the I18N template helper, which was (in my opinion) required to make it consistent with how the HTML rendering API and its usage of "values"feels.

Adds the same "reload" ability to i18n bundles that we have on HTML templates, so that in development, i18n bundles are re-compiled on each request, so they can be edited while a dev server is running without requiring a reload.