### PR TITLE
seatbelt: add "route" router method

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -64,7 +64,7 @@ func main() {
 		return c.String(200, c.I18N.T("Greet", nil))
 	})
 
-	app.Route("/admin", func(app *seatbelt.App) {
+	app.Namespace("/admin", func(app *seatbelt.App) {
 		app.Use(func(fn func(ctx *seatbelt.Context) error) func(*seatbelt.Context) error {
 			const name = "admin"
 

--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -64,5 +64,19 @@ func main() {
 		return c.String(200, c.I18N.T("Greet", nil))
 	})
 
+	app.Route("/admin", func(app *seatbelt.App) {
+		app.Use(func(fn func(ctx *seatbelt.Context) error) func(*seatbelt.Context) error {
+			const name = "admin"
+
+			return func(c *seatbelt.Context) error {
+				c.Values.Set("Name", name)
+				return fn(c)
+			}
+		})
+		app.Get("/home", func(c *seatbelt.Context) error {
+			return c.Render("admin", nil)
+		})
+	})
+
 	log.Fatalln(app.Start(":3000"))
 }

--- a/example/templates/admin.html
+++ b/example/templates/admin.html
@@ -1,7 +1,6 @@
-{{ define "title-index" }}{{ t "Home" . }}{{ end }}
-<h1 class="title">{{ t "Hello" . }}</h1>
+{{ define "title-admin" }}Admin{{ end }}
+<h1 class="title">Admin</h1>
 <p>{{ t "Greet" . }}</p>
 <p>{{ t "WelcomeMessage" . }}</p>
 <a href="/session">{{ t "SessionData" . }}</a>
 <a href="/txt">Plaintext link</a>
-<a href="/admin/home">Admin</a>

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -552,6 +552,29 @@ func (a *App) handle(verb, path string, handle func(c *Context) error) {
 	}
 }
 
+func (a *App) Route(pattern string, fn func(app *App)) *App {
+	if fn == nil {
+		panic(fmt.Sprintf("seatbelt: attempting to Route() a nil sub-app on '%s'", pattern))
+	}
+
+	subApp := &App{
+		signingKey:   a.signingKey,
+		i18n:         a.i18n,
+		session:      a.session,
+		renderer:     a.renderer,
+		errorHandler: a.errorHandler,
+		mux:          chi.NewRouter(),
+		// TODO Not sure if this is actually the behaviour we want -- should
+		// it inherit the middleware stack?
+		middlewares: make([]MiddlewareFunc, 0),
+	}
+
+	fn(subApp)
+	a.mux.Mount(pattern, subApp)
+
+	return subApp
+}
+
 // Head routes HEAD requests to the given path.
 func (a *App) Head(path string, handle func(c *Context) error) {
 	a.handle("HEAD", path, handle)

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -552,7 +552,9 @@ func (a *App) handle(verb, path string, handle func(c *Context) error) {
 	}
 }
 
-func (a *App) Route(pattern string, fn func(app *App)) *App {
+// Namespace creates a new *seatbelt.App with an empty middleware stack and
+// mounts it on the `pattern` as a subrouter.
+func (a *App) Namespace(pattern string, fn func(app *App)) *App {
 	if fn == nil {
 		panic(fmt.Sprintf("seatbelt: attempting to Route() a nil sub-app on '%s'", pattern))
 	}

--- a/seatbelt_test.go
+++ b/seatbelt_test.go
@@ -30,7 +30,7 @@ func TestSubRouter(t *testing.T) {
 	app.Get("/", func(c *Context) error {
 		return c.String(200, "home")
 	})
-	app.Route("/admin", func(app *App) {
+	app.Namespace("/admin", func(app *App) {
 		app.Get("/home", func(c *Context) error {
 			return c.String(200, "ok")
 		})

--- a/seatbelt_test.go
+++ b/seatbelt_test.go
@@ -1,6 +1,9 @@
 package seatbelt
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 )
@@ -17,6 +20,56 @@ func TestOptions(t *testing.T) {
 		}
 		if data == nil {
 			t.Fatal("file is empty")
+		}
+	})
+}
+
+func TestSubRouter(t *testing.T) {
+	app := New()
+
+	app.Get("/", func(c *Context) error {
+		return c.String(200, "home")
+	})
+	app.Route("/admin", func(app *App) {
+		app.Get("/home", func(c *Context) error {
+			return c.String(200, "ok")
+		})
+	})
+
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+
+	t.Run("GET /", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(data) != "home" {
+			t.Fatalf("expected home but got %s", data)
+		}
+	})
+
+	t.Run("GET /admin/home", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/admin/home")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(data) != "ok" {
+			t.Fatalf("expected ok but got %s", data)
 		}
 	})
 }


### PR DESCRIPTION
Adds Chi's `route` to the Seatbelt application's router.

This allows sub-routes to be created, as follows:

```go
app := app.New()
app.Route("/admin", func(app *App) {
    app.Get("/home", func(c *seatbelt.Context) error {
        return c.String(200, "ok")
    })
})
app.Start()
```

This will return 200 with the body "ok" when a request is sent to `/admin/home`.