### PR TITLE
seatbelt: add method to render tpl to bytes

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -26,6 +26,11 @@ func main() {
 	app.Get("/", func(c *seatbelt.Context) error {
 		return c.Render("index", nil)
 	})
+	app.Get("/rendertostring", func(c *seatbelt.Context) error {
+		page := c.RenderToBytes("index", nil)
+		_, err := c.Response().Write([]byte(page))
+		return err
+	})
 	app.Get("/session", func(c *seatbelt.Context) error {
 		return c.Render("session", map[string]interface{}{
 			"Session": c.Session.Get("session"),


### PR DESCRIPTION
Adds a method to render a template to a byte slice, rather than directly to the response writer. I needed this in a different project to render a byte slice in order to write it to a websocket connection.