### PR TITLE
seatbelt: favour secret env var over master.key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Restore cache
-      uses: actions/cache@v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Format
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,23 +10,27 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x ]
+        go-version: [ 1.23.x, 1.24.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
+
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
+
     - name: Checkout code
       uses: actions/checkout@v2
+
     - name: Restore cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+
     - name: Format
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       if: matrix.os == 'ubuntu-latest'

--- a/seatbelt.go
+++ b/seatbelt.go
@@ -330,14 +330,17 @@ func (o *Option) setDefaults() {
 // The "master.key" file is a secret and should be treated as such. It should
 // not be checked into your source code, and in production, the "SECRET"
 // environment variable should instead be used.
+//
+// The "SECRET" environment variable takes precendence over the "master.key"
+// file.
 func (o *Option) setMasterKey() {
-	if key := os.Getenv("SECRET"); key != "" {
-		o.SigningKey = key
-	}
-
 	if key, err := os.ReadFile("master.key"); err == nil {
 		o.SigningKey = string(key)
 		return
+	}
+
+	if key := os.Getenv("SECRET"); key != "" {
+		o.SigningKey = key
 	}
 
 	b := make([]byte, 32)


### PR DESCRIPTION
Inverts the secret key extraction logic so that the `SECRET` env var takes precedence over the `master.key` file.